### PR TITLE
check result of gethostbyname() to fix Segmentation fault error

### DIFF
--- a/src/MQTTClient.c
+++ b/src/MQTTClient.c
@@ -1739,6 +1739,8 @@ int http_post_json(char *json_data, char *hostname, uint16_t port, char *path, C
     servaddr.sin_family = AF_INET;
     servaddr.sin_port = htons(port);
     struct hostent *host_entry = gethostbyname(hostname);
+	if(host_entry == NULL)
+		return -1;
     char* p = inet_ntoa(*((struct in_addr *)host_entry->h_addr));
 	if (inet_pton(AF_INET, p, &servaddr.sin_addr) <= 0)
 		return -1;


### PR DESCRIPTION
In function http_post_json() of MQTTClient.c, the returned pointer of gethostbyname() was used without checking, which could cause "Segmentation fault" runtime error.
